### PR TITLE
Keep websocket connection alive

### DIFF
--- a/cmd/btpsimple/module/icon/client.go
+++ b/cmd/btpsimple/module/icon/client.go
@@ -316,7 +316,8 @@ func (c *Client) keepAlive(conn *websocket.Conn) {
 		for {
 			<-ticker.C
 			if err := conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(DefaultPingWait)); err != nil {
-				c.l.Warn("Ping failed error: %v", err)
+				c.l.Warn("fail to WriteControl err: %v", err)
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Whenever I try to put BTP running for a long time, it turns out this error:
```
btpsimple_src_1 | D|15:12:02.949106|19E7|-|icon|client.go:379 wsReadJSONLoop c.conns[192.168.128.3:55966] ReadJSON err:unexpected EOF
```

I believe this problem arose while I was working on my shaky network. To solve this problem, I'd like to add a keepalive function to the icon client.

P/S: After I added this function. BTP is working continuously 24 hours still now.