### PR TITLE
feat: support Mac OS build for docker-compose/goloop2moonbeam

### DIFF
--- a/docker-compose/goloop2moonbeam/Makefile
+++ b/docker-compose/goloop2moonbeam/Makefile
@@ -1,7 +1,6 @@
 clean:
 	docker-compose down -v --remove-orphans
-	rm -rf data
-	rm -rf config
+	rm -rf data config
 
 build:
 	docker-compose build

--- a/docker-compose/goloop2moonbeam/README.MD
+++ b/docker-compose/goloop2moonbeam/README.MD
@@ -3,6 +3,8 @@
 This document will walk you through setting up a Docker environment to demonstrate how to run BTP between ICON and MOONBEAM.   
 (Tested on macos 11.4 and ubuntu 18.04+)
 
+This is for development usage only, because running Blockchain Nodes requires larger computer resources. 
+
 ## Prerequisites:  
 ```
 - docker version 20.10.5+
@@ -14,13 +16,26 @@ This document will walk you through setting up a Docker environment to demonstra
 
 ## Setup steps:  
 
-For easy setup, we recommend to use a fresh ubuntu 21.04. Hence, run those commands to installe prerequire tools
+For easy setup, we recommend to use a fresh ubuntu 18.04. Hence, run those commands to installe prerequisite tools
 ```
 apt update
 apt install git make zip golang-go docker.io docker-compose --fix-missing -y
 sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
+
+For Mac OS, we recommend to use homebrew for prerequisites
+```
+brew install git make go dokcer docker-compose
+```
+
+## Computer specs
+
+At least 8 CPUs, 16 RAM.
+
+For Mac OS, you need to setup docker engine resoures after install docker
+
+![Docker Engine resources](https://user-images.githubusercontent.com/19373324/131948239-abf1fb38-fac6-443a-9a4e-a082966eb767.png)
 
 ### Build image btpsimple:latest
 
@@ -29,7 +44,7 @@ cd ~/work
 git clone git@github.com:icon-project/btp.git
 cd ~/work/btp
 git fetch
-git checkout goloop2moonbeam
+git checkout icondao
 make btpsimple-image
 ```
 
@@ -48,7 +63,7 @@ Note: If you want a fresh test, run `make clean` to remove the old test data.
 ### Run test scenarios:
 
 Keep the docker-compose running and open an other terminal.  
-Run this command to transfer the native coin ICX from ICON to MOONBEAN.
+Run this command to transfer the native coin ICX from ICON to MOONBEAN. FYI, numbers in the result are floating-point, so if they are `0,99` it will show as `0`, so you need to run `make transfer_icx` for the transferred balances to become `1,99`
 ```
 make transfer_icx
 ```

--- a/docker-compose/goloop2moonbeam/README.MD
+++ b/docker-compose/goloop2moonbeam/README.MD
@@ -61,7 +61,7 @@ Note: If you want a fresh test, run `make clean` to remove the old test data.
 ### Run test scenarios:
 
 Keep the docker-compose running and open an other terminal.  
-Run this command to transfer the native coin ICX from ICON to MOONBEAN. FYI, numbers in the result are floating-point, so if they are `0,99` it will show as `0`, so you need to run `make transfer_icx` for the transferred balances to become `1,99`
+Run this command to transfer the native coin ICX from ICON to MOONBEAN
 ```
 make transfer_icx
 ```

--- a/docker-compose/goloop2moonbeam/README.MD
+++ b/docker-compose/goloop2moonbeam/README.MD
@@ -31,7 +31,7 @@ brew install git make go dokcer docker-compose
 
 ## Computer specs
 
-At least 16 CPUs, 16 RAM.
+At least 16 CPUs, 8 RAM.
 
 For Mac OS, you need to setup docker engine resoures after install docker
 

--- a/docker-compose/goloop2moonbeam/README.MD
+++ b/docker-compose/goloop2moonbeam/README.MD
@@ -31,11 +31,9 @@ brew install git make go dokcer docker-compose
 
 ## Computer specs
 
-At least 8 CPUs, 16 RAM.
+At least 16 CPUs, 16 RAM.
 
 For Mac OS, you need to setup docker engine resoures after install docker
-
-![Docker Engine resources](https://user-images.githubusercontent.com/19373324/131948239-abf1fb38-fac6-443a-9a4e-a082966eb767.png)
 
 ### Build image btpsimple:latest
 

--- a/docker-compose/goloop2moonbeam/goloop/config/goloop.server.json
+++ b/docker-compose/goloop2moonbeam/goloop/config/goloop.server.json
@@ -30,8 +30,8 @@
       "mac": "1ef4ff51fdee8d4de9cf59e160da049eb0099eb691510994f5eca492f56c817a"
     }
   },
-  "log_level": "debug",
-  "console_level": "trace",
+  "log_level": "trace",
+  "console_level": "debug",
   "log_writer": {
     "filename": "../goloop.log",
     "maxsize": 100,

--- a/docker-compose/goloop2moonbeam/scripts/transfer_icx.sh
+++ b/docker-compose/goloop2moonbeam/scripts/transfer_icx.sh
@@ -37,8 +37,8 @@ transfer_ICX_from_Alice_to_Bob() {
 }
 
 check_bob_balance_in_Moonbeam() {
-    echo "$1. Checking Bob's balance after 10 seconds..."
-    sleep 10
+    echo "$1. Checking Bob's balance after 15 seconds..."
+    sleep 15
 
     cd $CONFIG_DIR
     eth abi:add bshcore abi.bsh_core.json


### PR DESCRIPTION
- In our development, goloop node is confirmed unstable during long run and we used gochain for long run.
- Contracts deployments and transfer still work.
- We tried to run only goloop container with 100 transfer ICX transactions concurrently and it’s ok.
- We changes icon.genesis.json with new attributes, goloop container still die out.
```
        "roundLimitFactor": "0x6",
        "commitTimeout": "0x3e8",
```

Problem with goloop containers on Mac Os, this problem doesn't occur on Ubuntu
- Using `docker-compose down -v --remove-orphans` in `make clean` cause
```
Traceback (most recent call last):
  File "requests/adapters.py", line 439, in send
  File "urllib3/connectionpool.py", line 726, in urlopen
  File "urllib3/util/retry.py", line 410, in increment
  File "urllib3/packages/six.py", line 735, in reraise
  File "urllib3/connectionpool.py", line 670, in urlopen
  File "urllib3/connectionpool.py", line 428, in _make_request
  File "urllib3/connectionpool.py", line 335, in _raise_timeout
urllib3.exceptions.ReadTimeoutError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "threading.py", line 950, in _bootstrap_inner
  File "threading.py", line 888, in run
  File "compose/cli/log_printer.py", line 202, in watch_events
  File "compose/project.py", line 626, in yield_loop
  File "compose/project.py", line 594, in build_container_event
  File "compose/container.py", line 44, in from_id
  File "docker/utils/decorators.py", line 19, in wrapped
  File "docker/api/container.py", line 774, in inspect_container
  File "docker/utils/decorators.py", line 46, in inner
  File "docker/api/client.py", line 237, in _get
  File "requests/sessions.py", line 543, in get
  File "requests/sessions.py", line 530, in request
  File "requests/sessions.py", line 643, in send
  File "requests/adapters.py", line 529, in send
requests.exceptions.ReadTimeout: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)

ERROR: for g2m_goloop  UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=70)
ERROR: An HTTP request took too long to complete. Retry with --verbose to obtain debug information.
If you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 60).
make: *** [Makefile:9: run] Error 1
```
- in order to stop goloop container, I have to restart docker-engine and `make clean` again
- goloop container still receive transactions all transactions before goloop hange up receiver PENDING error. In this time, goloop node doesn't produce blocks, logs.

Proposed solution:
- replace goloop image with gochain

Added:
- gochian image doesn't work too