### PR TITLE
Notify user if node version incorrect

### DIFF
--- a/e2edemo/package.json
+++ b/e2edemo/package.json
@@ -6,5 +6,8 @@
     "icon-sdk-js": "^1.2.12",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Check required node.js version. It should be higher than 18 LTS (to have fetch module intrinsically).